### PR TITLE
[BUG] Botões com fundo visível

### DIFF
--- a/flights_admin.html
+++ b/flights_admin.html
@@ -124,16 +124,26 @@
   
                 <div>
                     <label for="from" class="block text-base font-light text-Text-Subtitles">Origem</label>
-                    <select id="from" class="w-full h-11 bg-zinc-100 rounded-lg px-3" >
-                    
-                    </select>
+                    <div class="relative w-full">
+                        <select id="from" class="w-full h-11 bg-zinc-100 rounded-lg px-3 appearance-none" >
+                        
+                        </select>
+                        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center">
+                            <span class="material-symbols-outlined text-base cursor-pointer">keyboard_arrow_down</span>
+                        </div>
+                    </div>
                 </div>
   
                 <div>
                     <label for="to" class="block text-base font-light text-Text-Subtitles">Destino</label>
-                    <select id="to" class="w-full h-11 bg-zinc-100 rounded-lg px-3" >
+                    <div class="relative w-full">
+                        <select id="to" class="w-full h-11 bg-zinc-100 rounded-lg px-3 appearance-none">
                     
-                    </select>
+                        </select>
+                        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center">
+                            <span class="material-symbols-outlined text-base cursor-pointer">keyboard_arrow_down</span>
+                        </div>
+                    </div>
                 </div>
   
                 <div>
@@ -148,10 +158,15 @@
   
                 <div>
                     <label for="direct" class="block text-base font-light text-Text-Subtitles">Voo Direto (S/N)</label>
-                    <select id="direct" class="w-full h-11 bg-zinc-100 rounded-lg px-3">
-                        <option value="Sim">Sim</option>
-                        <option value="Não">Não</option>
-                    </select>
+                    <div class="relative w-full">
+                        <select id="direct" class="w-full h-11 bg-zinc-100 rounded-lg pl-3 appearance-none">
+                            <option value="Sim">Sim</option>
+                            <option value="Não">Não</option>
+                        </select>
+                        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center">
+                            <span class="material-symbols-outlined text-base cursor-pointer">keyboard_arrow_down</span>
+                        </div>
+                    </div>
                 </div>
             </form>
   


### PR DESCRIPTION
Fixes #66

1. Inserir o `<select>` dentro de uma `<div class="relative w-full">`
2. Remover a apearence default do `<select class="... appearance-none">`
3. Adicionar, ainda dentro da `<div class=relative w-full">`,  uma arrow personalizada  `<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center"><span class="material-symbols-outlined text-base cursor-pointer">keyboard_arrow_down</span> </div>` 

close[BUG] Botões com fundo visível #66 